### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# rhcl-i
-redhat dev installation
+# RHCL_I
+RedHat Developers Installation
 
 Prerequisites for running CDK
 The prerequisites for running CDK are:


### PR DESCRIPTION
**2.2. INSTALLING CLIENT TOOLS**

**2.2.1. Installing on Windows**
This section describes how to install the OpenShift Enterprise client tools on Windows operating systems. Instructions are also provided to install the necessary software that is required before the client tools can be installed.
Supported Windows Operating Systems
Windows 7
Windows Vista
Windows XP
Windows 2000
$ gem install rhc
When the installation completes, proceed to Section 2.3, “Configuring Client Tools” to configure the client tools using the interactive setup wizard.